### PR TITLE
Do not log "i/o timeout" errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/use-go/onvif
 
-go 1.14
+go 1.15
 
 require (
 	github.com/beevik/etree v1.1.0

--- a/ws-discovery/networking.go
+++ b/ws-discovery/networking.go
@@ -10,9 +10,11 @@ package wsdiscovery
  *******************************************************/
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -85,7 +87,9 @@ func sendUDPMulticast(msg string, interfaceName string) []string {
 		b := make([]byte, bufSize)
 		n, _, _, err := p.ReadFrom(b)
 		if err != nil {
-			fmt.Println(err)
+			if !errors.Is(err, os.ErrDeadlineExceeded) {
+				fmt.Println(err)
+			}
 			break
 		}
 		result = append(result, string(b[0:n]))


### PR DESCRIPTION
This commit avoids the logging of `read udp 0.0.0.0:1024: raw-read udp4 0.0.0.0:1024: i/o timeout` errors, when calling `wsdiscovery.SendProbe()` as this error is expected and used to exit the loop.